### PR TITLE
Regex-based comment extraction with support for multiple languages

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -78,6 +78,42 @@ Results in:
        original: 'var foo = "bar";' } ] }
 ```
 
+**Different comment styles and other languages**
+
+The `options` parameter can be used to specify a file-type and load comment-patterns for
+different languages. With the following Handlebars-file:
+
+```hbs
+{{!
+  This is a handlebars-file
+}}
+{{title}}
+```
+
+the following snippet
+
+```js
+var extract = require('extract-comments');
+
+// pass a string of handlebars etc
+extract(string, { filename: 'abc.hbs'});
+```
+
+results in
+
+```js
+{
+      '1': {
+        begin: 1,
+        code: '{{title}}',
+        codeStart: 4,
+        content: 'This is a handlebars-file\n',
+        end: 3
+      }
+}
+```
+
+
 ## Extracting from files
 
 Prior to v0.7.0, there was a method to extract code comments from files. Here is the equivalent code to accomplish the same thing:

--- a/fixtures/body.hbs
+++ b/fixtures/body.hbs
@@ -1,0 +1,17 @@
+{{!
+A comment without indent.
+}}
+{{>some-partial}}
+
+{{!
+  A comment with indent ...
+
+      ... and an other larger indent
+}}
+{{#if definitions}}
+    <h2>Definitions</h2>
+    {{!
+       Wholly indented comment
+    }}
+    {{>json-schema/definitions}}
+{{/if}}

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /*!
  * extract-comments <https://github.com/jonschlinkert/extract-comments>
  *
- * Copyright (c) 2014-2015, Jon Schlinkert.
+ * Copyright (c) 2014-2015, Nils Knappmeier.
  * Licensed under the MIT License.
  */
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,12 @@
+/*!
+ * extract-comments <https://github.com/jonschlinkert/extract-comments>
+ *
+ * Copyright (c) 2014-2015, Jon Schlinkert.
+ * Licensed under the MIT License.
+ */
+
+'use strict';
+
 var cp = require("comment-patterns");
 var Scanner = require("./scanner.js");
 var nextLineRegex = /.*$/mg;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /*!
  * extract-comments <https://github.com/jonschlinkert/extract-comments>
  *
- * Copyright (c) 2014-2015, Nils Knappmeier.
+ * Copyright (c) 2014-2015, Jon Schlinkert.
  * Licensed under the MIT License.
  */
 

--- a/index.js
+++ b/index.js
@@ -27,14 +27,18 @@ function extract(str, fn, options) {
   var codeEnd = null;
   new Scanner(regexp)
     .on("comment", function (comment) {
+      // Temporary save the comment
       lastComment = comment;
     })
     .on("codeStart", function (codeStartIndex) {
+      // Save the index of the first line of code after the comment
       codeStart = codeStartIndex;
     })
     .on("codeEnd", function (codeEndIndex) {
       codeEnd = codeEndIndex;
       if (lastComment) {
+        // Finalize the last comment: Retrieve the first line of code.
+        // At most up to the next comment
         nextLineRegex.lastIndex = codeStart;
         var match = nextLineRegex.exec(str);
         if (match[0].length > codeEnd - codeStart) {
@@ -51,6 +55,4 @@ function extract(str, fn, options) {
 }
 
 module.exports = extract;
-//var contents = fs.readFileSync("../extract-comments/fixtures/test.coffee", "utf-8");
-//console.log(extract(contents,{ filename: "test.coffee" }));
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "comment-patterns": "^0.3.0",
+    "comment-patterns": "^0.5.0",
     "line-counter": "^1.0.3",
     "quotemeta": "0.0.0"
   },
@@ -42,12 +42,13 @@
     "code",
     "parse",
     "javascript",
+    "handlebars",
     "block",
     "context",
     "comments",
     "comment",
     "extract",
-    "esprima",
+    "regex",
     "glob"
   ],
   "verb": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   },
   "dependencies": {
     "comment-patterns": "^0.3.0",
-    "line-counter": "^1.0.3"
+    "line-counter": "^1.0.3",
+    "quotemeta": "0.0.0"
   },
   "devDependencies": {
     "code-context": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "test": "mocha"
   },
   "dependencies": {
-    "is-whitespace": "^0.3.0"
+    "comment-patterns": "^0.3.0",
+    "line-counter": "^1.0.3"
   },
   "devDependencies": {
     "code-context": "^0.5.0",

--- a/scanner.js
+++ b/scanner.js
@@ -1,3 +1,10 @@
+/*!
+ * extract-comments <https://github.com/jonschlinkert/extract-comments>
+ *
+ * Copyright (c) 2014-2015, Nils Knappmeier.
+ * Licensed under the MIT License.
+ */
+
 'use strict';
 
 var q = require("quotemeta");

--- a/scanner.js
+++ b/scanner.js
@@ -56,6 +56,7 @@ function Scanner(pattern) {
       content = content.replace(indentRegex, "");
       var middle = pattern.middle[i - pattern.cg.contentStart];
       content = content.replace(middle, "");
+      // Remove empty lines from the beginning of the comment
       content = content.replace(/^[\n\r]*/, "");
 
       var commentEndIndex = match.index + match[cg.indent].length + match[cg.wholeComment].length;

--- a/scanner.js
+++ b/scanner.js
@@ -1,7 +1,7 @@
 /*!
  * extract-comments <https://github.com/jonschlinkert/extract-comments>
  *
- * Copyright (c) 2014-2015, Nils Knappmeier.
+ * Copyright (c) 2014-2015, Jon Schlinkert.
  * Licensed under the MIT License.
  */
 

--- a/scanner.js
+++ b/scanner.js
@@ -14,12 +14,11 @@ var util = require("util");
  * @param {number} pattern.cg.indent
  * @param {number} pattern.cg.wholeComment
  * @param {number} pattern.cg.contentStart
- * @param {number} pattern.cg.beforeCode
- * @param {number} pattern.cg.code
  * @constructor
  */
 function Scanner(pattern) {
   var _this = this;
+  // Shortcut for capturing group constants
   var cg = pattern.cg;
 
   /**
@@ -28,7 +27,7 @@ function Scanner(pattern) {
    * @returns {*}
    */
   function contentCg(commentMatch) {
-    var start = pattern.cg.contentStart;
+    var start = cg.contentStart;
     var end = start + pattern.middle.length;
     for (var i = start; i < end; i++) {
       if (typeof commentMatch[i] !== "undefined") {
@@ -46,16 +45,20 @@ function Scanner(pattern) {
     // The first part of the string is always code (if the string starts with
     // a comment, we treat is as if the is a zero-length code-part before the comment
     // This part ends with the beginning of the first comment
-    this.emit("codeStart",0);
+    this.emit("codeStart", 0);
     while ((match = pattern.regex.exec(contents)) != null) {
       // Find the matched capturing group for the comment-alternative of the regex
 
       var i = contentCg(match);
       var content = match[i];
-      var indentRegex = new RegExp("^" + q(match[cg.indent]), "mg");
-      content = content.replace(indentRegex, "");
-      var middle = pattern.middle[i - pattern.cg.contentStart];
-      content = content.replace(middle, "");
+      var middle = pattern.middle[i - cg.contentStart];
+      if (middle) {
+        // Remove middle-prefix and a possibly following single space
+        content = content.replace(middle, "").replace(/^ /gm, "");
+      } else {
+        var indentRegex = new RegExp("^" + q(minIndent(content)), "mg");
+        content = content.replace(indentRegex, "");
+      }
       // Remove empty lines from the beginning of the comment
       content = content.replace(/^[\n\r]*/, "");
 
@@ -63,7 +66,7 @@ function Scanner(pattern) {
       var codeStartIndex = match.index + match[0].length;
 
       // Comment found, code ends here
-      _this.emit("codeEnd",match.index);
+      _this.emit("codeEnd", match.index);
       // Emit the comment details
       _this.emit("comment",
         {
@@ -74,10 +77,44 @@ function Scanner(pattern) {
           content: content
         });
       // The start of the next code part
-      _this.emit("codeStart",match.index + match[0].length);
+      _this.emit("codeStart", match.index + match[0].length);
     }
-    _this.emit("codeEnd",contents.length);
+    _this.emit("codeEnd", contents.length);
   }
+}
+
+/**
+ * Determin the minimal indent of a multiline string.
+ * e.g.
+ * ```
+ *    abc
+ *        abd
+ *            abc
+ * ```
+ * has the minimal indent `   ` (three spaces)
+ * @param {string} `string` a multiline string
+ * @returns {string} a string of spaces or tabs
+ */
+function minIndent(string) {
+  var result = string
+    // Match all leading spaces with one following non-space (multiline)
+    // This results in an array where all relevant line-indents are present with
+    // on additional character
+    .match(/^[ \t]*\S/mg)
+    // Choose from all these the indent with the minimal length
+    // `min` is the string of minimal length (or `null` in the beginning).
+    // `current` is the current indent-string
+    .reduce(function (min, current) {
+      if (min === null) {
+        // Initial iteration
+        return current;
+      }
+      return min.length < current.length ? min : current;
+    }, null)
+    // Remove the last (the non-space) character
+    .slice(0, -1);
+
+  return result;
 }
 
 util.inherits(Scanner, EventEmitter);

--- a/scanner.js
+++ b/scanner.js
@@ -1,0 +1,84 @@
+'use strict';
+
+var q = require("quotemeta");
+var LineCounter = require("line-counter");
+var EventEmitter = require('events').EventEmitter;
+var util = require("util");
+
+/**
+ *
+ * @param {object} pattern
+ * @param {RegExp} pattern.regex
+ * @param {RegExp[]} pattern.middle
+ * @param {object} pattern.cg
+ * @param {number} pattern.cg.indent
+ * @param {number} pattern.cg.wholeComment
+ * @param {number} pattern.cg.contentStart
+ * @param {number} pattern.cg.beforeCode
+ * @param {number} pattern.cg.code
+ * @constructor
+ */
+function Scanner(pattern) {
+  var _this = this;
+  var cg = pattern.cg;
+
+  /**
+   * Return the spec that was responsible for a comment match
+   * @param commentMatch
+   * @returns {*}
+   */
+  function contentCg(commentMatch) {
+    var start = pattern.cg.contentStart;
+    var end = start + pattern.middle.length;
+    for (var i = start; i < end; i++) {
+      if (typeof commentMatch[i] !== "undefined") {
+        return i;
+      }
+    }
+    console.log(commentMatch);
+    throw new Error("No comment-part had a match. This should not happen");
+  }
+
+  this.scan = function (contents) {
+
+    var counter = new LineCounter(contents);
+    var match;
+    // The first part of the string is always code (if the string starts with
+    // a comment, we treat is as if the is a zero-length code-part before the comment
+    // This part ends with the beginning of the first comment
+    this.emit("codeStart",0);
+    while ((match = pattern.regex.exec(contents)) != null) {
+      // Find the matched capturing group for the comment-alternative of the regex
+
+      var i = contentCg(match);
+      var content = match[i];
+      var indentRegex = new RegExp("^" + q(match[cg.indent]), "mg");
+      content = content.replace(indentRegex, "");
+      var middle = pattern.middle[i - pattern.cg.contentStart];
+      content = content.replace(middle, "");
+      content = content.replace(/^[\n\r]*/, "");
+
+      var commentEndIndex = match.index + match[cg.indent].length + match[cg.wholeComment].length;
+      var codeStartIndex = match.index + match[0].length;
+
+      // Comment found, code ends here
+      _this.emit("codeEnd",match.index);
+      // Emit the comment details
+      _this.emit("comment",
+        {
+          // The order of the .countUpTo-calls must be preserved or errors will occur
+          begin: counter.countUpTo(match.index),
+          end: counter.countUpTo(commentEndIndex),
+          codeStart: counter.countUpTo(codeStartIndex),
+          content: content
+        });
+      // The start of the next code part
+      _this.emit("codeStart",match.index + match[0].length);
+    }
+    _this.emit("codeEnd",contents.length);
+  }
+}
+
+util.inherits(Scanner, EventEmitter);
+
+module.exports = Scanner;

--- a/test.js
+++ b/test.js
@@ -17,7 +17,7 @@ function read(fp) {
   return fs.readFileSync(__dirname + '/fixtures/' + fp, 'utf8');
 }
 
-describe('extract comments', function () {
+describe('extract comments from javascript', function () {
   it('should extract comments from a string.', function () {
     extract('/**\n * this is\n *\n * a comment\n*/\nvar foo = "bar";\n').should.eql({
       '1': {
@@ -73,4 +73,43 @@ describe('extract comments', function () {
     var comments = extract(str);
     comments['1274'].codeStart.should.equal(1291);
   });
+});
+
+
+describe("extract comments from Handlebars", function () {
+  var str = read('body.hbs');
+  var comments = extract(str, {
+    filename: 'body.hbs'
+  });
+
+  it('a simple comment', function () {
+    comments['1'].should.eql({
+      begin: 1,
+      end: 3,
+      codeStart: 4,
+      content: 'A comment without indent.\n',
+      code: '{{>some-partial}}'
+    });
+  });
+
+  it('a comment with indent content. Indents should be removed such that the smallest indent is 0', function () {
+    comments['6'].should.eql({
+      begin: 6,
+      end: 10,
+      codeStart: 11,
+      content: 'A comment with indent ...\n\n    ... and an other larger indent\n',
+      code: '{{#if definitions}}'
+    });
+  });
+
+  it('a comment with indent content and delimiters', function () {
+    comments['13'].should.eql({
+        begin: 13,
+        end: 15,
+        codeStart: 16,
+        content: 'Wholly indented comment\n    ',
+        code: '    {{>json-schema/definitions}}'
+      }
+    );
+  })
 });

--- a/test.js
+++ b/test.js
@@ -25,7 +25,7 @@ describe('extract comments', function () {
         begin: 1,
         end: 5,
         code: 'var foo = "bar";',
-        codeStart: 7
+        codeStart: 6
       }
     });
   });
@@ -37,7 +37,7 @@ describe('extract comments', function () {
         begin: 1,
         end: 3,
         code: 'next line',
-        codeStart: 5
+        codeStart: 4
       }
     })
   });


### PR DESCRIPTION
This pull-request is again, for issue #1, but this time I have done a (more or less complete) rewrite of the module:

The whole string is scanned by a precomputed regex from the `comment-patterns` module. An `options`-parameter is added to the `extract` function. A filename can by specified via `options.filename`. It is used to determine the language with  the `comment-patterns` module. The `line-counter`-module is used to keep track of line-numbers while scanning the string.

I was not sure about the performance of scanning the whole file via regex, so I [have set up a performance-test](https://github.com/nknapp/comment-benchmark) for different methods of scanning the file. The main result is that iterating lines of a string is (for the "Template" index-file) slower (2720 ops/sec)  than using a regex to match the whole next comment (4470 ops/sec). 

Finally, test cases were not all running, but after looking-closely, I believe this test-expectations are not fully correct. The first test case is on the string

``` js
/**
 * this is
 *
 * a comment
*/
var foo = "bar";
```

and `codeStart` is expected to be on line 7, but it is actually 6. The reason why the test passes in your master branch is that it always iterates two lines-of-code after the comment and updates the `codeStart`-property on each iteration.
**This is also something, where my code actually returns different results**: The regex, that matches the comment, also matches empty lines after the comment and `codeStart` is expected to be after that. The 'next line of code' after that is exactly the `codeStart` line (not two), so 

``` js
/**
 * comment
 */
var foo = "bar";
```

and

``` js
/**
 * comment
 */

var foo = "bar";
```

and

``` js
/**
 * comment
 */




var foo = "bar";
```

and 

``` js
/**
 * comment
 */
var foo = "bar";
var fooh = "baah";
```

all have `var foo = "bar";` as "next-line-of-code" with `codeStart` being 4,5,8 and 4 respectively.
For the last example, the the current master returns `var foo = "bar";var fooh = "baah";`.

I have not written any tests yet to confirm that the PR works with different languages.
