### PR TITLE
Catch code that immediately follows a comment, fixes #9

### DIFF
--- a/lib/code.js
+++ b/lib/code.js
@@ -6,7 +6,7 @@ var utils = require('./utils');
 function Code(str, comment) {
   str = utils.restore(str);
   var start = comment.loc.end.pos;
-  var lineno = comment.loc.end.line + 1;
+  var lineno = comment.loc.end.line;
   var ctx = {};
 
   var lines = str.split('\n').slice(lineno);

--- a/test/test.js
+++ b/test/test.js
@@ -151,6 +151,12 @@ describe('code', function() {
     assert.equal(actual[0].code.value, 'var foo = "bar";');
   });
 
+  it('should not get a comment following a comment', function() {
+    var str = '/**\n * this is\n *\n * a comment\n*/\n// var one = two';
+    var actual = extract(str);
+    assert.equal(actual[0].code.value, '');
+  });
+
   it('should get the code starting and ending indices', function() {
     var str = '/**\n * this is\n *\n * a comment\n*/\n\n\nvar foo = "bar";\n';
     var actual = extract(str);

--- a/test/test.js
+++ b/test/test.js
@@ -151,6 +151,12 @@ describe('code', function() {
     assert.equal(actual[0].code.value, 'var foo = "bar";');
   });
 
+  it('should get a code line that immediately follows the comment', function() {
+    var str = '/**\n * this is\n *\n * a comment\n*/\nvar foo = "bar";\n// var one = two';
+    var actual = extract(str);
+    assert.equal(actual[0].code.value, 'var foo = "bar";');
+  });
+
   it('should not get a comment following a comment', function() {
     var str = '/**\n * this is\n *\n * a comment\n*/\n// var one = two';
     var actual = extract(str);


### PR DESCRIPTION
I noticed that code on the line after comment wasn't captured in the context:

``` js
/**
 * Some comment
 */
var someCode;
```

I was just able to start the context search one line sooner to catch this.

I also added another test to make sure comments following comments weren't captured as code context.
